### PR TITLE
Provide per product version report

### DIFF
--- a/check/caller.go
+++ b/check/caller.go
@@ -71,8 +71,12 @@ func (vc *callerImpl) Call(r *VersionCheckRequest) (*VersionCheckResponse, error
 }
 
 func validateResponse(r *VersionCheckResponse) error {
-	if r.Current.Version == "" || r.Recommended.Version == "" {
-		return errors.New("invalid response: missing current or recommended version")
+	if len(r.Products) == 0 {
+		return errors.New("invalid response: missing product list")
+	}
+	firstProduct := r.Products[0]
+	if firstProduct.Product == "" || firstProduct.Current.Version == "" || firstProduct.Recommended.Version == "" {
+		return errors.New("invalid response: missing product name, current or recommended version")
 	}
 	return nil
 }

--- a/check/caller_test.go
+++ b/check/caller_test.go
@@ -2,14 +2,13 @@ package check
 
 import (
 	"encoding/json"
-	"testing"
-	"time"
 	"io/ioutil"
-	"net/url"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
 )
-
 
 func TestPostInfo(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -34,18 +33,23 @@ func TestPostInfo(t *testing.T) {
 		}
 		// Unmarshalling works
 		res, err := json.Marshal(VersionCheckResponse{
-			Current:      ReleaseInfo {
-				Version: "0.1",
-				ReleaseTime: time.Now().UnixNano(),
-				Notes: "",
+			Products: []ProductVersionReport{
+				ProductVersionReport{
+					Product: "server",
+					Current: ReleaseInfo{
+						Version:     "0.1",
+						ReleaseTime: time.Now().UnixNano(),
+						Notes:       "",
+					},
+					Recommended: ReleaseInfo{
+						Version:     "0.1",
+						ReleaseTime: time.Now().UnixNano(),
+						Notes:       "",
+					},
+					Instructions: "instructions",
+					Alerts:       []Alert{},
+				},
 			},
-			Recommended:  ReleaseInfo {
-				Version: "0.1",
-				ReleaseTime: time.Now().UnixNano(),
-				Notes: "",
-			},
-			Instructions: "instructions",
-			Alerts:       []Alert{},
 		})
 		if err != nil {
 			t.Fatalf("Failed to marshal response %s", err)
@@ -58,9 +62,8 @@ func TestPostInfo(t *testing.T) {
 	}
 	caller := &callerImpl{url.Scheme, url.Host}
 	sdkInfo := []SDKInfo{{
-		Name: "sdk-java",
+		Name:    "sdk-java",
 		Version: "3.11",
-		TimesSeen: 23,
 	}}
 	_, err = caller.Call(&VersionCheckRequest{
 		Product:   "server",

--- a/check/request.go
+++ b/check/request.go
@@ -1,10 +1,9 @@
 package check
 
-// VersionCheckRequest provides basic info about the client and is used to produce VersionCheckResponse.
+// SDKINfo is a tuple of (SDK name, SDK version)
 type SDKInfo struct {
-	Name      string `json:"sdkName"`
-	Version   string `json:"sdkVersion"`
-	TimesSeen int64  `json:"timesSeen"`
+	Name    string `json:"sdkName"`
+	Version string `json:"sdkVersion"`
 }
 
 // VersionCheckRequest provides basic info about the client and is used to produce VersionCheckResponse.

--- a/check/response.go
+++ b/check/response.go
@@ -27,10 +27,16 @@ type Alert struct {
 	Severity Severity `json:"severity"`
 }
 
-// VersionCheckResponse contains recommendation about the best version of the product, any alerts for the current version as well as upgrade instructions.
-type VersionCheckResponse struct {
+// ProductVersionReport contains recommendation about the best version of a product, any alerts for the current version as well as upgrade instructions.
+type ProductVersionReport struct {
+	Product      string      `json:"product"`
 	Current      ReleaseInfo `json:"current"`
 	Recommended  ReleaseInfo `json:"recommended"`
 	Instructions string      `json:"instructions"`
 	Alerts       []Alert     `json:"alerts"`
+}
+
+// VersionCheckResponse is either a VersionCheckReport (where product is empty) or a list of per product updates.
+type VersionCheckResponse struct {
+	Products []ProductVersionReport `json:"products"`
 }


### PR DESCRIPTION
This was overlooked in the previous PR, there needs to be a way to get per product updates (SDK, server)